### PR TITLE
Packaging with pyinstaller and github actions

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create App Bundle
 

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -29,16 +29,16 @@ jobs:
         if: runner.os == 'Linux'
         with:
           name: loguetools-${{ runner.os }}
-          path: '**/*.AppImage'
+          path: '**/dist/**'
       - name: Upload Artifact for MacOS
         uses: actions/upload-artifact@v2
         if: runner.os == 'MacOS'
         with:
           name: loguetools-${{ runner.os }}
-          path: '**/*.app'
+          path: '**/dist/**'
       - name: Upload Artifact for Windows
         uses: actions/upload-artifact@v2
         if: runner.os == 'Windows'
         with:
           name: loguetools-${{ runner.os }}
-          path: '**/*.exe'
+          path: '**/dist/**'

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,0 +1,44 @@
+on: [push, pull_request]
+
+name: Create App Bundle
+
+jobs:
+  bundle:
+    name: Bundle on ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyinstaller
+          python -m pip freeze
+      - name: Create and Build Bundle
+        run: pyinstaller --clean --windowed --onefile main.spec
+      - name: Upload Artifact for Linux
+        uses: actions/upload-artifact@v2
+        if: runner.os == 'Linux'
+        with:
+          name: loguetools-${{ runner.os }}
+          path: '**/*.AppImage'
+      - name: Upload Artifact for MacOS
+        uses: actions/upload-artifact@v2
+        if: runner.os == 'MacOS'
+        with:
+          name: loguetools-${{ runner.os }}
+          path: '**/*.app'
+      - name: Upload Artifact for Windows
+        uses: actions/upload-artifact@v2
+        if: runner.os == 'Windows'
+        with:
+          name: loguetools-${{ runner.os }}
+          path: '**/*.exe'


### PR DESCRIPTION
Skeleton github workflow for creating pyinstaller bundled apps for Windows, Mac +& Linux.

Notes:
* I'm not sure I've done it correctly with pyinstaller (there might need to be some other dependencies in the build environment too?). I wasn't able to launch the GUI in general, even before packaging with pyinstaller.
* You can have a look at what pyinstaller outputs here: https://github.com/GenevieveBuckley/loguetools/actions/runs/312406537
* You can comment out the line requiring a tag beginning with v from the github action script if you want to play with this on your own branch.