### PR TITLE
Fix linux wxpython installation for packaging

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-16.04, macos-latest, windows-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install wxPython dependency n Linux
         if: runner.os == 'Linux'
         run: |
-          apt-get install python-wxgtk3.0
+          sudo apt-get install python-wxgtk3.0
           python -m pip freeze
       - name: Create and Build Bundle
         run: pyinstaller --clean --windowed --onefile main.spec

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,8 +1,8 @@
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    # tags:
+    #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create App Bundle
 
@@ -34,9 +34,7 @@ jobs:
       - name: Install wxPython dependency n Linux
         if: runner.os == 'Linux'
         run: |
-          python -m pip install -U \
-              -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 \
-              wxPython
+          apt-get install python-wxgtk3.0
           python -m pip freeze
       - name: Create and Build Bundle
         run: pyinstaller --clean --windowed --onefile main.spec

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,8 +1,8 @@
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    # tags:
-    #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create App Bundle
 

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -26,7 +26,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyinstaller
           python -m pip install click
+      - name: Install wxPython dependency on Windows/Mac
+        if: runner.os != 'Linux'
+        run: |
           python -m pip install wxpython
+          python -m pip freeze
+      - name: Install wxPython dependency n Linux
+        if: runner.os == 'Linux'
+        run: |
+          python -m pip install -U \
+              -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 \
+              wxPython
           python -m pip freeze
       - name: Create and Build Bundle
         run: pyinstaller --clean --windowed --onefile main.spec


### PR DESCRIPTION
This PR fixes the wxpython dependency installation for linux packaging.

It does NOT fix the problem where the loguetools file is considered a text file instead of an executable (same problem we've seen on Mac)